### PR TITLE
vidconv: add support for converting to/from YUV444 and RGB32

### DIFF
--- a/src/vidconv/vconv.c
+++ b/src/vidconv/vconv.c
@@ -180,6 +180,21 @@ static inline void yuv2rgb555(uint8_t *rgb, uint8_t y,
 }
 
 
+static inline void _yuv2rgb(uint8_t *rgb, uint8_t y, uint8_t u, uint8_t v)
+{
+	int ruv, guv, buv;
+
+	ruv = CRV[v];
+	guv = CGV[v] + CGU[u];
+	buv = CBU[u];
+
+	*rgb++ = saturate_u8(y + buv);
+	*rgb++ = saturate_u8(y + guv);
+	*rgb++ = saturate_u8(y + ruv);
+	*rgb   = 0;
+}
+
+
 typedef void (line_h)(unsigned xoffs, unsigned width, double rw,
 		      unsigned yd, unsigned ys, unsigned ys2,
 		      uint8_t *dd0, uint8_t *dd1, uint8_t *dd2,
@@ -338,6 +353,57 @@ static void rgb32_to_yuv420p(unsigned xoffs, unsigned width, double rw,
 
 		dd1[id] = rgb2u(x0 >> 16, x0 >> 8, x0);
 		dd2[id] = rgb2v(x0 >> 16, x0 >> 8, x0);
+	}
+}
+
+
+static void rgb32_to_yuv444p(unsigned xoffs, unsigned width, double rw,
+			     unsigned yd, unsigned ys, unsigned ys2,
+			     uint8_t *dd0, uint8_t *dd1, uint8_t *dd2,
+			     unsigned lsd,
+			     const uint8_t *ds0, const uint8_t *ds1,
+			     const uint8_t *ds2, unsigned lss
+			     )
+{
+	unsigned x, xd, xs, xs2;
+	unsigned id;
+
+	(void)ds1;
+	(void)ds2;
+
+	for (x=0; x<width; x+=2) {
+
+		uint32_t x0;
+		uint32_t x1;
+		uint32_t x2;
+		uint32_t x3;
+
+		xd  = x + xoffs;
+
+		xs  = 4 * ((unsigned)( x    * rw));
+		xs2 = 4 * ((unsigned)((x+1) * rw));
+
+		id = xd + yd*lsd;
+
+		x0 = *(uint32_t *)(void *)&ds0[xs  + ys*lss];
+		x1 = *(uint32_t *)(void *)&ds0[xs2 + ys*lss];
+		x2 = *(uint32_t *)(void *)&ds0[xs  + ys2*lss];
+		x3 = *(uint32_t *)(void *)&ds0[xs2 + ys2*lss];
+
+		dd0[id]         = rgb2y(x0 >> 16, x0 >> 8, x0);
+		dd0[id+1]       = rgb2y(x1 >> 16, x1 >> 8, x1);
+		dd0[id + lsd]   = rgb2y(x2 >> 16, x2 >> 8, x2);
+		dd0[id+1 + lsd] = rgb2y(x3 >> 16, x3 >> 8, x3);
+
+		dd1[id]         = rgb2u(x0 >> 16, x0 >> 8, x0);
+		dd1[id+1]       = rgb2u(x1 >> 16, x1 >> 8, x1);
+		dd1[id + lsd]   = rgb2u(x2 >> 16, x2 >> 8, x2);
+		dd1[id+1 + lsd] = rgb2u(x3 >> 16, x3 >> 8, x3);
+
+		dd2[id]         = rgb2v(x0 >> 16, x0 >> 8, x0);
+		dd2[id+1]       = rgb2v(x1 >> 16, x1 >> 8, x1);
+		dd2[id + lsd]   = rgb2v(x2 >> 16, x2 >> 8, x2);
+		dd2[id+1 + lsd] = rgb2v(x3 >> 16, x3 >> 8, x3);
 	}
 }
 
@@ -573,6 +639,42 @@ static void nv21_to_yuv420p(unsigned xoffs, unsigned width, double rw,
 }
 
 
+static void yuv444p_to_rgb32(unsigned xoffs, unsigned width, double rw,
+			     unsigned yd, unsigned ys, unsigned ys2,
+			     uint8_t *dd0, uint8_t *dd1, uint8_t *dd2,
+			     unsigned lsd,
+			     const uint8_t *ds0, const uint8_t *ds1,
+			     const uint8_t *ds2, unsigned lss)
+{
+	unsigned x, xd, xs, xs2;
+	unsigned id;
+	unsigned is1, is2, is3, is4;
+
+	(void)dd1;
+	(void)dd2;
+
+	for (x=0; x<width; x+=2) {
+
+		xd  = (x + xoffs) * 4;
+
+		xs  = (unsigned)(x * rw);
+		xs2 = (unsigned)((x+1) * rw);
+
+		id = (xd + yd*lsd);
+
+		is1  = (xs)  + (ys )*lss;
+		is2  = (xs2) + (ys )*lss;
+		is3  = (xs)  + (ys2)*lss;
+		is4  = (xs2) + (ys2)*lss;
+
+		_yuv2rgb(&dd0[id],         ds0[is1], ds1[is1], ds2[is1] );
+		_yuv2rgb(&dd0[id+4],       ds0[is2], ds1[is2], ds2[is2] );
+		_yuv2rgb(&dd0[id   + lsd], ds0[is3], ds1[is3], ds2[is3] );
+		_yuv2rgb(&dd0[id+4 + lsd], ds0[is4], ds1[is4], ds2[is4] );
+	}
+}
+
+
 static void nv12_to_rgb32(unsigned xoffs, unsigned width, double rw,
                            unsigned yd, unsigned ys, unsigned ys2,
                            uint8_t *dd0, uint8_t *dd1, uint8_t *dd2,
@@ -655,8 +757,9 @@ static void nv21_to_rgb32(unsigned xoffs, unsigned width, double rw,
 }
 
 
-#define MAX_SRC 9
-#define MAX_DST 8
+#define MAX_SRC 10
+#define MAX_DST 10
+
 
 /**
  * Pixel conversion table:  [src][dst]
@@ -672,7 +775,8 @@ static line_h *conv_table[MAX_SRC][MAX_DST] = {
 	 yuv420p_to_rgb565, yuv420p_to_rgb555, yuv420p_to_nv12},
 	{yuyv422_to_yuv420p,  NULL,     NULL,     NULL, NULL, NULL, NULL},
 	{uyvy422_to_yuv420p,  NULL,     NULL,     NULL, NULL, NULL, NULL},
-	{rgb32_to_yuv420p,    NULL,     NULL,     NULL, NULL, NULL, NULL},
+	{rgb32_to_yuv420p,    NULL,     NULL,     NULL, NULL, NULL, NULL,
+	 NULL, NULL, rgb32_to_yuv444p},
 	{rgb32_to_yuv420p,    NULL,     NULL,     NULL, NULL, NULL, NULL},
 	{NULL,                NULL,     NULL,     NULL, NULL, NULL, NULL},
 	{NULL,                NULL,     NULL,     NULL, NULL, NULL, NULL},
@@ -680,6 +784,7 @@ static line_h *conv_table[MAX_SRC][MAX_DST] = {
 	 NULL, NULL, NULL},
 	{nv21_to_yuv420p,     NULL,     NULL,     nv21_to_rgb32,
 	 NULL, NULL, NULL},
+	{NULL,                NULL,     NULL,     yuv444p_to_rgb32}
 };
 
 

--- a/src/vidconv/vconv.c
+++ b/src/vidconv/vconv.c
@@ -371,25 +371,25 @@ static void rgb32_to_yuv444p(unsigned xoffs, unsigned width, double rw,
 	for (x=0; x<width; x++) {
 
 		uint32_t x0;
-		uint32_t x2;
+		uint32_t x1;
 
-		xd  = x + xoffs;
+		xd = x + xoffs;
 
-		xs  = 4 * ((unsigned)( x * rw));
+		xs = 4 * ((unsigned)(x * rw));
 
 		id = xd + yd*lsd;
 
-		x0 = *(uint32_t *)(void *)&ds0[xs  + ys *lss];
-		x2 = *(uint32_t *)(void *)&ds0[xs  + ys2*lss];
+		x0 = *(uint32_t *)(void *)&ds0[xs + ys *lss];
+		x1 = *(uint32_t *)(void *)&ds0[xs + ys2*lss];
 
-		dd0[id]         = rgb2y(x0 >> 16, x0 >> 8, x0);
-		dd0[id + lsd]   = rgb2y(x2 >> 16, x2 >> 8, x2);
+		dd0[id]       = rgb2y(x0 >> 16, x0 >> 8, x0);
+		dd0[id + lsd] = rgb2y(x1 >> 16, x1 >> 8, x1);
 
-		dd1[id]         = rgb2u(x0 >> 16, x0 >> 8, x0);
-		dd1[id + lsd]   = rgb2u(x2 >> 16, x2 >> 8, x2);
+		dd1[id]       = rgb2u(x0 >> 16, x0 >> 8, x0);
+		dd1[id + lsd] = rgb2u(x1 >> 16, x1 >> 8, x1);
 
-		dd2[id]         = rgb2v(x0 >> 16, x0 >> 8, x0);
-		dd2[id + lsd]   = rgb2v(x2 >> 16, x2 >> 8, x2);
+		dd2[id]       = rgb2v(x0 >> 16, x0 >> 8, x0);
+		dd2[id + lsd] = rgb2v(x1 >> 16, x1 >> 8, x1);
 	}
 }
 
@@ -641,17 +641,17 @@ static void yuv444p_to_rgb32(unsigned xoffs, unsigned width, double rw,
 
 	for (x=0; x<width; x++) {
 
-		xd  = (x + xoffs) * 4;
+		xd = (x + xoffs) * 4;
 
-		xs  = (unsigned)(x * rw);
+		xs = (unsigned)(x * rw);
 
 		id = (xd + yd*lsd);
 
-		is1  = (xs) + (ys )*lss;
-		is2  = (xs) + (ys2)*lss;
+		is1 = (xs) + (ys )*lss;
+		is2 = (xs) + (ys2)*lss;
 
-		_yuv2rgb(&dd0[id],       ds0[is1], ds1[is1], ds2[is1] );
-		_yuv2rgb(&dd0[id + lsd], ds0[is2], ds1[is2], ds2[is2] );
+		_yuv2rgb(&dd0[id],       ds0[is1], ds1[is1], ds2[is1]);
+		_yuv2rgb(&dd0[id + lsd], ds0[is2], ds1[is2], ds2[is2]);
 	}
 }
 

--- a/src/vidconv/vconv.c
+++ b/src/vidconv/vconv.c
@@ -635,31 +635,26 @@ static void yuv444p_to_rgb32(unsigned xoffs, unsigned width, double rw,
 			     const uint8_t *ds0, const uint8_t *ds1,
 			     const uint8_t *ds2, unsigned lss)
 {
-	unsigned x, xd, xs, xs2;
+	unsigned x, xd, xs;
 	unsigned id;
-	unsigned is1, is2, is3, is4;
+	unsigned is1, is2;
 
 	(void)dd1;
 	(void)dd2;
 
-	for (x=0; x<width; x+=2) {
+	for (x=0; x<width; x++) {
 
 		xd  = (x + xoffs) * 4;
 
 		xs  = (unsigned)(x * rw);
-		xs2 = (unsigned)((x+1) * rw);
 
 		id = (xd + yd*lsd);
 
-		is1  = (xs)  + (ys )*lss;
-		is2  = (xs2) + (ys )*lss;
-		is3  = (xs)  + (ys2)*lss;
-		is4  = (xs2) + (ys2)*lss;
+		is1  = (xs) + (ys )*lss;
+		is2  = (xs) + (ys2)*lss;
 
-		_yuv2rgb(&dd0[id],         ds0[is1], ds1[is1], ds2[is1] );
-		_yuv2rgb(&dd0[id+4],       ds0[is2], ds1[is2], ds2[is2] );
-		_yuv2rgb(&dd0[id   + lsd], ds0[is3], ds1[is3], ds2[is3] );
-		_yuv2rgb(&dd0[id+4 + lsd], ds0[is4], ds1[is4], ds2[is4] );
+		_yuv2rgb(&dd0[id],       ds0[is1], ds1[is1], ds2[is1] );
+		_yuv2rgb(&dd0[id + lsd], ds0[is2], ds1[is2], ds2[is2] );
 	}
 }
 

--- a/src/vidconv/vconv.c
+++ b/src/vidconv/vconv.c
@@ -188,10 +188,7 @@ static inline void _yuv2rgb(uint8_t *rgb, uint8_t y, uint8_t u, uint8_t v)
 	guv = CGV[v] + CGU[u];
 	buv = CBU[u];
 
-	*rgb++ = saturate_u8(y + buv);
-	*rgb++ = saturate_u8(y + guv);
-	*rgb++ = saturate_u8(y + ruv);
-	*rgb   = 0;
+	yuv2rgb(rgb, y, ruv, guv, buv);
 }
 
 

--- a/src/vidconv/vconv.c
+++ b/src/vidconv/vconv.c
@@ -645,10 +645,10 @@ static void yuv444p_to_rgb32(unsigned xoffs, unsigned width, double rw,
 
 		xs = (unsigned)(x * rw);
 
-		id = (xd + yd*lsd);
+		id = xd + yd*lsd;
 
-		is1 = (xs) + (ys )*lss;
-		is2 = (xs) + (ys2)*lss;
+		is1 = xs + ys *lss;
+		is2 = xs + ys2*lss;
 
 		_yuv2rgb(&dd0[id],       ds0[is1], ds1[is1], ds2[is1]);
 		_yuv2rgb(&dd0[id + lsd], ds0[is2], ds1[is2], ds2[is2]);

--- a/src/vidconv/vconv.c
+++ b/src/vidconv/vconv.c
@@ -365,45 +365,34 @@ static void rgb32_to_yuv444p(unsigned xoffs, unsigned width, double rw,
 			     const uint8_t *ds2, unsigned lss
 			     )
 {
-	unsigned x, xd, xs, xs2;
+	unsigned x, xd, xs;
 	unsigned id;
 
 	(void)ds1;
 	(void)ds2;
 
-	for (x=0; x<width; x+=2) {
+	for (x=0; x<width; x++) {
 
 		uint32_t x0;
-		uint32_t x1;
 		uint32_t x2;
-		uint32_t x3;
 
 		xd  = x + xoffs;
 
-		xs  = 4 * ((unsigned)( x    * rw));
-		xs2 = 4 * ((unsigned)((x+1) * rw));
+		xs  = 4 * ((unsigned)( x * rw));
 
 		id = xd + yd*lsd;
 
-		x0 = *(uint32_t *)(void *)&ds0[xs  + ys*lss];
-		x1 = *(uint32_t *)(void *)&ds0[xs2 + ys*lss];
+		x0 = *(uint32_t *)(void *)&ds0[xs  + ys *lss];
 		x2 = *(uint32_t *)(void *)&ds0[xs  + ys2*lss];
-		x3 = *(uint32_t *)(void *)&ds0[xs2 + ys2*lss];
 
 		dd0[id]         = rgb2y(x0 >> 16, x0 >> 8, x0);
-		dd0[id+1]       = rgb2y(x1 >> 16, x1 >> 8, x1);
 		dd0[id + lsd]   = rgb2y(x2 >> 16, x2 >> 8, x2);
-		dd0[id+1 + lsd] = rgb2y(x3 >> 16, x3 >> 8, x3);
 
 		dd1[id]         = rgb2u(x0 >> 16, x0 >> 8, x0);
-		dd1[id+1]       = rgb2u(x1 >> 16, x1 >> 8, x1);
 		dd1[id + lsd]   = rgb2u(x2 >> 16, x2 >> 8, x2);
-		dd1[id+1 + lsd] = rgb2u(x3 >> 16, x3 >> 8, x3);
 
 		dd2[id]         = rgb2v(x0 >> 16, x0 >> 8, x0);
-		dd2[id+1]       = rgb2v(x1 >> 16, x1 >> 8, x1);
 		dd2[id + lsd]   = rgb2v(x2 >> 16, x2 >> 8, x2);
-		dd2[id+1 + lsd] = rgb2v(x3 >> 16, x3 >> 8, x3);
 	}
 }
 


### PR DESCRIPTION
Add support for video converting:

- From YUV444 to RGB32
- From RGB32 to YUV444

tested with Baresip and Retest.

This is the last patch for the YUV444 pixelformat for now :)
