### PR TITLE
debian: enable dh_makeshlibs in rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -83,7 +83,7 @@ binary-arch: build install
 	dh_fixperms
 #	dh_perl
 #	dh_python
-#	dh_makeshlibs
+	dh_makeshlibs
 	dh_installdeb
 	dh_shlibdeps
 	dh_gencontrol


### PR DESCRIPTION
it turns out that this change is also needed, same as libre.

without it, building applications using librem fails because it cannot find the file librem.so.0
