### PR TITLE
g711: fix ALAW and ULAW encoding

### DIFF
--- a/include/rem_g711.h
+++ b/include/rem_g711.h
@@ -18,8 +18,9 @@ extern const int16_t g711_A2l[256];
  *
  * @return U-law byte
  */
-static inline uint8_t g711_pcm2ulaw(int32_t l)
+static inline uint8_t g711_pcm2ulaw(int16_t lx)
 {
+	int32_t l = lx;
 	const uint8_t mask = (l < 0) ? 0x7f : 0xff;
 	if (l < 0)
 		l = -l;

--- a/include/rem_g711.h
+++ b/include/rem_g711.h
@@ -43,7 +43,7 @@ static inline uint8_t g711_pcm2alaw(int16_t l)
 {
 	const uint8_t mask = (l < 0) ? 0x7f : 0xff;
 	if (l < 0)
-		l = -l;
+		l = ~l;
 	l >>= 4;
 
 	return g711_l2A[l] & mask;

--- a/include/rem_g711.h
+++ b/include/rem_g711.h
@@ -18,7 +18,7 @@ extern const int16_t g711_A2l[256];
  *
  * @return U-law byte
  */
-static inline uint8_t g711_pcm2ulaw(int16_t l)
+static inline uint8_t g711_pcm2ulaw(int32_t l)
 {
 	const uint8_t mask = (l < 0) ? 0x7f : 0xff;
 	if (l < 0)


### PR DESCRIPTION
the ALAW encoding has been verified against Spandsp with this code:

```c
#include <re.h>
#include <rem_g711.h>
#include <spandsp.h>


int main(void)
{
	int i;
	uint8_t alaw_ref;
	uint8_t alaw;
	unsigned count = 0;
	unsigned errors = 0;

	for (i = -32768; i <= 32767; i++) {

		int16_t sample = i;

		alaw_ref = linear_to_alaw(sample);
		alaw     = g711_pcm2alaw(sample);

		if (alaw != alaw_ref) {
			re_printf("ERROR! sample=%d:  ref=%u  rem=%u\n",
				  sample, alaw_ref, alaw);

			++errors;
		}

		++count;
	}

	re_printf("samples verified: %u\n", count);
	re_printf("errors:           %u\n", errors);
}
```



with the current code, there are 128 samples with the wrong value:


```
ERROR! sample=-32768:  ref=42  rem=15
ERROR! sample=-31744:  ref=43  rem=42
ERROR! sample=-30720:  ref=40  rem=43
ERROR! sample=-29696:  ref=41  rem=40
ERROR! sample=-28672:  ref=46  rem=41
ERROR! sample=-27648:  ref=47  rem=46
ERROR! sample=-26624:  ref=44  rem=47
ERROR! sample=-25600:  ref=45  rem=44
ERROR! sample=-24576:  ref=34  rem=45
ERROR! sample=-23552:  ref=35  rem=34
ERROR! sample=-22528:  ref=32  rem=35
ERROR! sample=-21504:  ref=33  rem=32
ERROR! sample=-20480:  ref=38  rem=33
ERROR! sample=-19456:  ref=39  rem=38
ERROR! sample=-18432:  ref=36  rem=39
ERROR! sample=-17408:  ref=37  rem=36
ERROR! sample=-16384:  ref=58  rem=37
ERROR! sample=-15872:  ref=59  rem=58
ERROR! sample=-15360:  ref=56  rem=59
ERROR! sample=-14848:  ref=57  rem=56
ERROR! sample=-14336:  ref=62  rem=57
ERROR! sample=-13824:  ref=63  rem=62
ERROR! sample=-13312:  ref=60  rem=63
ERROR! sample=-12800:  ref=61  rem=60
ERROR! sample=-12288:  ref=50  rem=61
ERROR! sample=-11776:  ref=51  rem=50
ERROR! sample=-11264:  ref=48  rem=51
ERROR! sample=-10752:  ref=49  rem=48
ERROR! sample=-10240:  ref=54  rem=49
ERROR! sample=-9728:  ref=55  rem=54
ERROR! sample=-9216:  ref=52  rem=55
ERROR! sample=-8704:  ref=53  rem=52
ERROR! sample=-8192:  ref=10  rem=53
ERROR! sample=-7936:  ref=11  rem=10
ERROR! sample=-7680:  ref=8  rem=11
ERROR! sample=-7424:  ref=9  rem=8
ERROR! sample=-7168:  ref=14  rem=9
ERROR! sample=-6912:  ref=15  rem=14
ERROR! sample=-6656:  ref=12  rem=15
ERROR! sample=-6400:  ref=13  rem=12
ERROR! sample=-6144:  ref=2  rem=13
ERROR! sample=-5888:  ref=3  rem=2
ERROR! sample=-5632:  ref=0  rem=3
ERROR! sample=-5376:  ref=1  rem=0
ERROR! sample=-5120:  ref=6  rem=1
ERROR! sample=-4864:  ref=7  rem=6
ERROR! sample=-4608:  ref=4  rem=7
ERROR! sample=-4352:  ref=5  rem=4
ERROR! sample=-4096:  ref=26  rem=5
ERROR! sample=-3968:  ref=27  rem=26
ERROR! sample=-3840:  ref=24  rem=27
ERROR! sample=-3712:  ref=25  rem=24
ERROR! sample=-3584:  ref=30  rem=25
ERROR! sample=-3456:  ref=31  rem=30
ERROR! sample=-3328:  ref=28  rem=31
ERROR! sample=-3200:  ref=29  rem=28
ERROR! sample=-3072:  ref=18  rem=29
ERROR! sample=-2944:  ref=19  rem=18
ERROR! sample=-2816:  ref=16  rem=19
ERROR! sample=-2688:  ref=17  rem=16
ERROR! sample=-2560:  ref=22  rem=17
ERROR! sample=-2432:  ref=23  rem=22
ERROR! sample=-2304:  ref=20  rem=23
ERROR! sample=-2176:  ref=21  rem=20
ERROR! sample=-2048:  ref=106  rem=21
ERROR! sample=-1984:  ref=107  rem=106
ERROR! sample=-1920:  ref=104  rem=107
ERROR! sample=-1856:  ref=105  rem=104
ERROR! sample=-1792:  ref=110  rem=105
ERROR! sample=-1728:  ref=111  rem=110
ERROR! sample=-1664:  ref=108  rem=111
ERROR! sample=-1600:  ref=109  rem=108
ERROR! sample=-1536:  ref=98  rem=109
ERROR! sample=-1472:  ref=99  rem=98
ERROR! sample=-1408:  ref=96  rem=99
ERROR! sample=-1344:  ref=97  rem=96
ERROR! sample=-1280:  ref=102  rem=97
ERROR! sample=-1216:  ref=103  rem=102
ERROR! sample=-1152:  ref=100  rem=103
ERROR! sample=-1088:  ref=101  rem=100
ERROR! sample=-1024:  ref=122  rem=101
ERROR! sample=-992:  ref=123  rem=122
ERROR! sample=-960:  ref=120  rem=123
ERROR! sample=-928:  ref=121  rem=120
ERROR! sample=-896:  ref=126  rem=121
ERROR! sample=-864:  ref=127  rem=126
ERROR! sample=-832:  ref=124  rem=127
ERROR! sample=-800:  ref=125  rem=124
ERROR! sample=-768:  ref=114  rem=125
ERROR! sample=-736:  ref=115  rem=114
ERROR! sample=-704:  ref=112  rem=115
ERROR! sample=-672:  ref=113  rem=112
ERROR! sample=-640:  ref=118  rem=113
ERROR! sample=-608:  ref=119  rem=118
ERROR! sample=-576:  ref=116  rem=119
ERROR! sample=-544:  ref=117  rem=116
ERROR! sample=-512:  ref=74  rem=117
ERROR! sample=-496:  ref=75  rem=74
ERROR! sample=-480:  ref=72  rem=75
ERROR! sample=-464:  ref=73  rem=72
ERROR! sample=-448:  ref=78  rem=73
ERROR! sample=-432:  ref=79  rem=78
ERROR! sample=-416:  ref=76  rem=79
ERROR! sample=-400:  ref=77  rem=76
ERROR! sample=-384:  ref=66  rem=77
ERROR! sample=-368:  ref=67  rem=66
ERROR! sample=-352:  ref=64  rem=67
ERROR! sample=-336:  ref=65  rem=64
ERROR! sample=-320:  ref=70  rem=65
ERROR! sample=-304:  ref=71  rem=70
ERROR! sample=-288:  ref=68  rem=71
ERROR! sample=-272:  ref=69  rem=68
ERROR! sample=-256:  ref=90  rem=69
ERROR! sample=-240:  ref=91  rem=90
ERROR! sample=-224:  ref=88  rem=91
ERROR! sample=-208:  ref=89  rem=88
ERROR! sample=-192:  ref=94  rem=89
ERROR! sample=-176:  ref=95  rem=94
ERROR! sample=-160:  ref=92  rem=95
ERROR! sample=-144:  ref=93  rem=92
ERROR! sample=-128:  ref=82  rem=93
ERROR! sample=-112:  ref=83  rem=82
ERROR! sample=-96:  ref=80  rem=83
ERROR! sample=-80:  ref=81  rem=80
ERROR! sample=-64:  ref=86  rem=81
ERROR! sample=-48:  ref=87  rem=86
ERROR! sample=-32:  ref=84  rem=87
ERROR! sample=-16:  ref=85  rem=84
samples verified: 65536
errors:           128
```


with this patch applied all samples matches values from spandsp:

```
./a.out 
samples verified: 65536
errors:           0
```



